### PR TITLE
Remove the prefix from sensor path elements.

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -29,6 +29,7 @@ import logging
 import json
 import os
 import time
+import re
 
 from elasticsearch import Elasticsearch
 
@@ -1122,7 +1123,7 @@ def build_tree(jsont, module, pass_on_schemas=None, augments=False):
         for path_part in path_list:
             path = '{}/{}'.format(path, path_part.split('?')[0])
         node['data']['path'] = path
-        node['data']['sensor_path'] = path.replace('/', '/{}:'.format(module), 1)
+        node['data']['sensor_path'] = re.sub(r'/[^:]+:', '/', path).replace('/', '/{}:'.format(module), 1)
     if jsont['name'] != module and jsont.get('children') is None or len(jsont['children']) == 0:
         node['icon'] = 'glyphicon glyphicon-leaf'
         if jsont.get('path') is not None:


### PR DESCRIPTION
This makes it easier for other tools to consume.